### PR TITLE
#207 created CODEOWNERS to reflect new ownership for repository files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# Default owners for everything in the repo
+* @jgiannuzzi @marcin-krystianc @mfkl @adamreeve @naskio @pavlovic-ivan @ljubon @BnMcG @m4rs-mt
+
+# Website and documentation
+/docs/ @naskio @jgiannuzzi
+
+# Build and CI files
+/.github/ @jgiannuzzi @marcin-krystianc
+*.yml @jgiannuzzi @marcin-krystianc
+*.yaml @jgiannuzzi @marcin-krystianc
+
+# Core library code
+/Consul/ @jgiannuzzi @marcin-krystianc @mfkl @adamreeve
+
+# Tests
+/Consul.Test/ @jgiannuzzi @marcin-krystianc @mfkl @adamreeve
+
+# ASP.NET Core integration
+/Consul.AspNetCore/ @BnMcG @pavlovic-ivan @ljubon


### PR DESCRIPTION
# Added CODEOWNERS file 

Created a CODEOWNERS file that reflects ownership on the differents part of the code.

For defining the ownership from the maintainers, I used GitLens, GItBlame, and the Github repo insights to see which maintainer tended to contribute to what part of the code. However, this should be further reviewed before merging to ensure that it is correct.

Done @tabathad !
